### PR TITLE
Context-Guided Splitting: poc in TruffleRuby (1/2)

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -7,7 +7,7 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "42ffc2408ec1bf9d45389d5293bba495ed51b8e7",
+                "version": "b82e6578cdcbc3d17c56ba887ada8f2de67c7575",
                 "urls": [
                     {"url": "https://github.com/sophie-kaleba/truffle.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "sulong",
                 "subdir": True,
-                "version": "42ffc2408ec1bf9d45389d5293bba495ed51b8e7",
+                "version": "b82e6578cdcbc3d17c56ba887ada8f2de67c7575",
                 "urls": [
                     {"url": "https://github.com/sophie-kaleba/truffle.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -7,7 +7,7 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "39a555c93a2de919f094aa6417a7c018417b1348",
+                "version": "42ffc2408ec1bf9d45389d5293bba495ed51b8e7",
                 "urls": [
                     {"url": "https://github.com/sophie-kaleba/truffle.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "sulong",
                 "subdir": True,
-                "version": "39a555c93a2de919f094aa6417a7c018417b1348",
+                "version": "42ffc2408ec1bf9d45389d5293bba495ed51b8e7",
                 "urls": [
                     {"url": "https://github.com/sophie-kaleba/truffle.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -144,7 +144,9 @@ public abstract class MethodNodes {
             final Object[] newArgs = RubyArguments.repack(callerRubyArgs, receiver);
             RubyArguments.setMethod(newArgs, internalMethod);
             assert RubyArguments.assertFrameArguments(newArgs);
-            return callInternalMethodNode.execute(frame, internalMethod, receiver, newArgs, null);
+            // TODO - check signature here, too
+            long contextSignature = -99;
+            return callInternalMethodNode.execute(frame, internalMethod, receiver, newArgs, null, contextSignature);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -40,6 +40,7 @@ import org.truffleruby.annotations.Visibility;
 import org.truffleruby.language.arguments.ArgumentDescriptorUtils;
 import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
+import org.truffleruby.language.contextualdispatch.ContextSignatureUtils;
 import org.truffleruby.language.control.BreakID;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.methods.CallInternalMethodNode;
@@ -144,8 +145,8 @@ public abstract class MethodNodes {
             final Object[] newArgs = RubyArguments.repack(callerRubyArgs, receiver);
             RubyArguments.setMethod(newArgs, internalMethod);
             assert RubyArguments.assertFrameArguments(newArgs);
-            // TODO - check signature here, too
-            long contextSignature = -99;
+
+            long contextSignature = ContextSignatureUtils.getContextSignature(RubyArguments.getRawArguments(callerRubyArgs));
             return callInternalMethodNode.execute(frame, internalMethod, receiver, newArgs, null, contextSignature);
         }
     }

--- a/src/main/java/org/truffleruby/core/method/RubyMethod.java
+++ b/src/main/java/org/truffleruby/core/method/RubyMethod.java
@@ -16,6 +16,7 @@ import org.truffleruby.interop.ForeignToRubyArgumentsNode;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
+import org.truffleruby.language.contextualdispatch.ContextSignatureUtils;
 import org.truffleruby.language.methods.CallInternalMethodNode;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.objects.ObjectGraph;
@@ -73,8 +74,7 @@ public class RubyMethod extends RubyDynamicObject implements ObjectGraphNode {
         final Object[] convertedArguments = foreignToRubyArgumentsNode.executeConvert(arguments);
         final Object[] frameArgs = RubyArguments.pack(null, null, method, null, receiver, nil,
                 EmptyArgumentsDescriptor.INSTANCE, convertedArguments);
-        // TODO - we can get a signature out of the converted arguments
-        long contextSignature = -77;
+        long contextSignature = ContextSignatureUtils.getContextSignature(convertedArguments);
         return callInternalMethodNode.execute(null, method, receiver, frameArgs, null, contextSignature);
     }
     // endregion

--- a/src/main/java/org/truffleruby/core/method/RubyMethod.java
+++ b/src/main/java/org/truffleruby/core/method/RubyMethod.java
@@ -73,7 +73,9 @@ public class RubyMethod extends RubyDynamicObject implements ObjectGraphNode {
         final Object[] convertedArguments = foreignToRubyArgumentsNode.executeConvert(arguments);
         final Object[] frameArgs = RubyArguments.pack(null, null, method, null, receiver, nil,
                 EmptyArgumentsDescriptor.INSTANCE, convertedArguments);
-        return callInternalMethodNode.execute(null, method, receiver, frameArgs, null);
+        // TODO - we can get a signature out of the converted arguments
+        long contextSignature = -77;
+        return callInternalMethodNode.execute(null, method, receiver, frameArgs, null, contextSignature);
     }
     // endregion
 

--- a/src/main/java/org/truffleruby/core/proc/RubyProc.java
+++ b/src/main/java/org/truffleruby/core/proc/RubyProc.java
@@ -102,6 +102,11 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
         ObjectGraph.addProperty(reachable, declaringMethod);
     }
 
+    @Override
+    public long getClassHashCode() {
+        return callTarget.hashCode();
+    }
+
     public boolean isLambda() {
         // The field is public, but the function is needed for use in guards.
         return type == ProcType.LAMBDA;

--- a/src/main/java/org/truffleruby/language/RubyDynamicObject.java
+++ b/src/main/java/org/truffleruby/language/RubyDynamicObject.java
@@ -82,6 +82,10 @@ public abstract class RubyDynamicObject extends DynamicObject {
         return metaClass;
     }
 
+    public long getClassHashCode() {
+        return metaClass.hashCode();
+    }
+
     public void setMetaClass(RubyClass metaClass) {
         SharedObjects.assertPropagateSharing(this, metaClass);
         this.metaClass = metaClass;

--- a/src/main/java/org/truffleruby/language/contextualdispatch/ContextSignatureUtils.java
+++ b/src/main/java/org/truffleruby/language/contextualdispatch/ContextSignatureUtils.java
@@ -1,0 +1,29 @@
+package org.truffleruby.language.contextualdispatch;
+
+import org.truffleruby.language.RubyDynamicObject;
+
+public class ContextSignatureUtils {
+
+    public static final int[] primeForSignature = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97};
+
+    public static long getArgumentHashcode(Object value) {
+        if (value != null) {
+            if (value instanceof RubyDynamicObject) {
+                return ((RubyDynamicObject) value).getClassHashCode();
+            }
+            return value.getClass().hashCode();
+        }
+        return 0;
+    }
+
+    public static long getContextSignature(Object[] args){
+        long contextSignature = 0;
+
+        for (int i = 0; i < args.length; i++) {
+            int j = i % ContextSignatureUtils.primeForSignature.length;
+            contextSignature += ContextSignatureUtils.getArgumentHashcode(args[i]) * ContextSignatureUtils.primeForSignature[j];
+        }
+
+        return contextSignature;
+    }
+}

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -298,12 +298,12 @@ public class DispatchNode extends SpecialVariablesSendingNode {
     }
 
     protected final Object dispatchInternal(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-                                        LiteralCallNode literalCallNode,
-                                        MetaClassNode metaClassNode,
-                                        LookupMethodNode lookupMethodNode,
-                                        ConditionProfile methodMissingProfile,
-                                        CallInternalMethodNode callNode,
-                                        long contextSignature) {
+            LiteralCallNode literalCallNode,
+            MetaClassNode metaClassNode,
+            LookupMethodNode lookupMethodNode,
+            ConditionProfile methodMissingProfile,
+            CallInternalMethodNode callNode,
+            long contextSignature) {
         assert RubyArguments.getSelf(rubyArgs) == receiver;
 
         final RubyClass metaclass = metaClassNode.execute(receiver);
@@ -442,7 +442,7 @@ public class DispatchNode extends SpecialVariablesSendingNode {
 
         @Override
         public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-                           LiteralCallNode literalCallNode) {
+                LiteralCallNode literalCallNode) {
             long contextSignature = ContextSignatureUtils.getContextSignature(RubyArguments.getRawArguments(rubyArgs));
             return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
                     MetaClassNodeGen.getUncached(),

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -33,6 +33,7 @@ import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.KeywordArgumentsDescriptorManager;
 import org.truffleruby.language.arguments.RubyArguments;
+import org.truffleruby.language.contextualdispatch.ContextSignatureUtils;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.methods.CallForeignMethodNode;
 import org.truffleruby.language.methods.CallInternalMethodNode;
@@ -285,7 +286,7 @@ public class DispatchNode extends SpecialVariablesSendingNode {
 
     public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
                            LiteralCallNode literalCallNode) {
-        long contextSignature = -44;
+        long contextSignature = ContextSignatureUtils.getContextSignature(RubyArguments.getRawArguments(rubyArgs));
         return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
                 metaclassNode, methodLookup, methodMissing, callNode, contextSignature);
     }
@@ -440,13 +441,14 @@ public class DispatchNode extends SpecialVariablesSendingNode {
 
         @Override
         public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-                               LiteralCallNode literalCallNode) {
-            long contextSignature = -55;
+                           LiteralCallNode literalCallNode) {
+            long contextSignature = ContextSignatureUtils.getContextSignature(RubyArguments.getRawArguments(rubyArgs));
             return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
                     MetaClassNodeGen.getUncached(),
                     LookupMethodNodeGen.getUncached(),
                     ConditionProfile.getUncached(),
-                    CallInternalMethodNodeGen.getUncached(), contextSignature);
+                    CallInternalMethodNodeGen.getUncached(),
+                    contextSignature);
         }
 
         @Override

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -284,17 +284,24 @@ public class DispatchNode extends SpecialVariablesSendingNode {
     }
 
     public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-            LiteralCallNode literalCallNode) {
+                           LiteralCallNode literalCallNode) {
+        long contextSignature = -44;
         return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
-                metaclassNode, methodLookup, methodMissing, callNode);
+                metaclassNode, methodLookup, methodMissing, callNode, contextSignature);
+    }
+
+    public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
+                           LiteralCallNode literalCallNode, long contextSignature) {
+        return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
+                metaclassNode, methodLookup, methodMissing, callNode, contextSignature);
     }
 
     protected final Object dispatchInternal(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-            LiteralCallNode literalCallNode,
-            MetaClassNode metaClassNode,
-            LookupMethodNode lookupMethodNode,
-            ConditionProfile methodMissingProfile,
-            CallInternalMethodNode callNode) {
+                                            LiteralCallNode literalCallNode,
+                                            MetaClassNode metaClassNode,
+                                            LookupMethodNode lookupMethodNode,
+                                            ConditionProfile methodMissingProfile,
+                                            CallInternalMethodNode callNode, long contextSignature) {
         assert RubyArguments.getSelf(rubyArgs) == receiver;
 
         final RubyClass metaclass = metaClassNode.execute(receiver);
@@ -318,7 +325,7 @@ public class DispatchNode extends SpecialVariablesSendingNode {
         RubyArguments.setCallerSpecialVariables(rubyArgs, getSpecialVariablesIfRequired(frame));
 
         assert RubyArguments.assertFrameArguments(rubyArgs);
-        return callNode.execute(frame, method, receiver, rubyArgs, literalCallNode);
+        return callNode.execute(frame, method, receiver, rubyArgs, literalCallNode, contextSignature);
     }
 
     @InliningCutoff
@@ -433,12 +440,13 @@ public class DispatchNode extends SpecialVariablesSendingNode {
 
         @Override
         public Object dispatch(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-                LiteralCallNode literalCallNode) {
+                               LiteralCallNode literalCallNode) {
+            long contextSignature = -55;
             return dispatchInternal(frame, receiver, methodName, rubyArgs, literalCallNode,
                     MetaClassNodeGen.getUncached(),
                     LookupMethodNodeGen.getUncached(),
                     ConditionProfile.getUncached(),
-                    CallInternalMethodNodeGen.getUncached());
+                    CallInternalMethodNodeGen.getUncached(), contextSignature);
         }
 
         @Override

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -298,11 +298,12 @@ public class DispatchNode extends SpecialVariablesSendingNode {
     }
 
     protected final Object dispatchInternal(Frame frame, Object receiver, String methodName, Object[] rubyArgs,
-                                            LiteralCallNode literalCallNode,
-                                            MetaClassNode metaClassNode,
-                                            LookupMethodNode lookupMethodNode,
-                                            ConditionProfile methodMissingProfile,
-                                            CallInternalMethodNode callNode, long contextSignature) {
+                                        LiteralCallNode literalCallNode,
+                                        MetaClassNode metaClassNode,
+                                        LookupMethodNode lookupMethodNode,
+                                        ConditionProfile methodMissingProfile,
+                                        CallInternalMethodNode callNode,
+                                        long contextSignature) {
         assert RubyArguments.getSelf(rubyArgs) == receiver;
 
         final RubyClass metaclass = metaClassNode.execute(receiver);

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -162,7 +162,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
     }
 
     public Object doCall(VirtualFrame frame, Object receiverObject, ArgumentsDescriptor descriptor, Object[] rubyArgs,
-            boolean ruby2KeywordsHash) {
+            boolean ruby2KeywordsHash, long contextSignature) {
         // Remove empty kwargs in the caller, so the callee does not need to care about this special case
         if (descriptor instanceof KeywordArgumentsDescriptor && emptyKeywordArguments(rubyArgs)) {
             rubyArgs = removeEmptyKeywordArguments(rubyArgs);

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -67,7 +67,6 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
 
     @Child private SplatToArgsNode splatToArgs;
 
-
     public RubyCallNode(RubyCallNodeParameters parameters) {
         this(
                 parameters.isSplatted(),

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -18,7 +18,6 @@ import org.truffleruby.core.array.RubyArray;
 import org.truffleruby.core.cast.BooleanCastNode;
 import org.truffleruby.core.cast.BooleanCastNodeGen;
 import org.truffleruby.core.inlined.LambdaToProcNode;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.language.RubyBaseNode;
@@ -30,6 +29,7 @@ import org.truffleruby.language.arguments.KeywordArgumentsDescriptor;
 import org.truffleruby.language.arguments.KeywordArgumentsDescriptorManager;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.arguments.SplatToArgsNode;
+import org.truffleruby.language.contextualdispatch.ContextSignatureUtils;
 import org.truffleruby.language.literal.NilLiteralNode;
 import org.truffleruby.language.methods.BlockDefinitionNode;
 import org.truffleruby.language.methods.InternalMethod;
@@ -66,7 +66,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
     private final CountingConditionProfile nilProfile;
 
     @Child private SplatToArgsNode splatToArgs;
-    private final int[] primeForSignature = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97};
+
 
     public RubyCallNode(RubyCallNodeParameters parameters) {
         this(
@@ -210,20 +210,16 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
     }
 
     @ExplodeLoop
-    private void executeArguments(VirtualFrame frame, Object[] rubyArgs) {
+    private long executeArguments(VirtualFrame frame, Object[] rubyArgs) {
+        long contextSignature = 0;
+        int j;
+
         for (int i = 0; i < arguments.length; i++) {
             Object value = arguments[i].execute(frame);
             RubyArguments.setArgument(rubyArgs, i, value);
-            if (value != null) {
-                int j = i % primeForSignature.length;
-                if (value instanceof RubyBasicObject) {
-                    contextSignature += ((RubyBasicObject) value).getMetaClass().hashCode() * primeForSignature[j];
-                } else if (value instanceof RubyProc){
-                    contextSignature += ((RubyProc) value).callTarget.hashCode() * primeForSignature[j];
-                } else {
-                    contextSignature += value.getClass().hashCode() * primeForSignature[j];
-                }
-            }
+
+            j = i % ContextSignatureUtils.primeForSignature.length;
+            contextSignature += ContextSignatureUtils.getArgumentHashcode(value) * ContextSignatureUtils.primeForSignature[j];
         }
     }
 

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -196,7 +196,9 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
         RubyArguments.setSelf(rubyArgs, receiverObject);
         RubyArguments.setBlock(rubyArgs, blockObject);
         RubyArguments.setArguments(rubyArgs, argumentsObjects);
-        return doCall(frame, receiverObject, descriptor, rubyArgs, false);
+
+        long contextSignature = ContextSignatureUtils.getContextSignature(RubyArguments.getRawArguments(rubyArgs));
+        return doCall(frame, receiverObject, descriptor, rubyArgs, false, contextSignature);
     }
 
     private Object executeBlock(VirtualFrame frame) {

--- a/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
@@ -148,13 +148,14 @@ public abstract class CallInternalMethodNode extends RubyBaseNode {
                 receiver,
                 rubyArgs,
                 literalCallNode,
-                isAdoptable());
+                isAdoptable(),
+                contextSignature);
     }
 
     @TruffleBoundary // getUncachedAlwaysInlinedMethodNode(method) and arity are not PE constants
     private Object alwaysInlinedBoundary(
             MaterializedFrame frame, InternalMethod method, Object receiver, Object[] rubyArgs,
-            LiteralCallNode literalCallNode, boolean cachedToUncached) {
+            LiteralCallNode literalCallNode, boolean cachedToUncached, long contextSignature) {
         EncapsulatingNodeReference encapsulating = null;
         Node prev = null;
         if (cachedToUncached) {
@@ -162,7 +163,6 @@ public abstract class CallInternalMethodNode extends RubyBaseNode {
             prev = encapsulating.set(this);
         }
         try {
-            long contextSignature = -66;
             return alwaysInlined(
                     frame,
                     method,

--- a/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
@@ -49,13 +49,10 @@ public abstract class CallInternalMethodNode extends RubyBaseNode {
         return CallInternalMethodNodeGen.create();
     }
 
-//    /** Callers should use {@link RubyArguments#assertFrameArguments} unless they use {@code RubyArguments#pack}.
-//     * {@code literalCallNode} is only non-null if this was called splatted with a ruby2_keyword Hash. */
-//    public abstract Object execute(Frame frame, InternalMethod method, Object receiver, Object[] rubyArgs,
-//            LiteralCallNode literalCallNode);
-
+    /** Callers should use {@link RubyArguments#assertFrameArguments} unless they use {@code RubyArguments#pack}.
+     * {@code literalCallNode} is only non-null if this was called splatted with a ruby2_keyword Hash. */
     public abstract Object execute(Frame frame, InternalMethod method, Object receiver, Object[] rubyArgs,
-                                   LiteralCallNode literalCallNode, long contextSignature);
+            LiteralCallNode literalCallNode, long contextSignature);
 
     @Specialization(
             guards = {

--- a/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
@@ -56,7 +56,9 @@ public class CallSuperMethodNode extends SpecialVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.pack(
                 null, callerSpecialVariables, superMethod, null, self, block, descriptor, arguments);
 
-        return getCallMethodNode().execute(frame, superMethod, self, rubyArgs, literalCallNode);
+        // TODO - check arguments here too
+        long contextSignature = -88;
+        return getCallMethodNode().execute(frame, superMethod, self, rubyArgs, literalCallNode, contextSignature);
     }
 
     private CallInternalMethodNode getCallMethodNode() {

--- a/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
@@ -13,6 +13,7 @@ import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.language.SpecialVariablesSendingNode;
 import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
+import org.truffleruby.language.contextualdispatch.ContextSignatureUtils;
 import org.truffleruby.language.dispatch.DispatchNode;
 import org.truffleruby.language.dispatch.LiteralCallNode;
 import org.truffleruby.language.methods.CallInternalMethodNode;
@@ -56,8 +57,7 @@ public class CallSuperMethodNode extends SpecialVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.pack(
                 null, callerSpecialVariables, superMethod, null, self, block, descriptor, arguments);
 
-        // TODO - check arguments here too
-        long contextSignature = -88;
+        long contextSignature = ContextSignatureUtils.getContextSignature(arguments);
         return getCallMethodNode().execute(frame, superMethod, self, rubyArgs, literalCallNode, contextSignature);
     }
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1116,7 +1116,7 @@ module Commands
 
     @ruby_name = "rebench"
     vm_args, ruby_args, options = ruby_options(options, args)
-    ruby_launcher_rebench = "/tmp/truffleruby/truffleruby-jvm-ce/bin/truffleruby"
+    ruby_launcher = '/tmp/truffleruby/truffleruby-jvm-ce/bin/truffleruby'
 
     sh env_vars, ruby_launcher_rebench, *(vm_args if truffleruby?), *ruby_args, options
   end

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -240,9 +240,9 @@ module Utilities
                     elsif @ruby_name.start_with?('/')
                       File.directory?(@ruby_name) ? "#{@ruby_name}/bin/ruby" : @ruby_name
                     elsif @ruby_name == 'rebench'
-                      "/tmp/truffleruby/truffleruby-jvm-ce/bin/truffleruby"
+                      '/tmp/truffleruby/truffleruby-jvm-ce/bin/truffleruby'
                     elsif @ruby_name == 'rebench-native'
-                      "/tmp/truffleruby/truffleruby-native-libgraal/bin/truffleruby"
+                      '/tmp/truffleruby/truffleruby-native-libgraal/bin/truffleruby'
                     elsif @ruby_name == 'ce'
                       "#{TRUFFLERUBY_DIR}/mxbuild/truffleruby-jvm-ce/bin/truffleruby"
                     else
@@ -1103,9 +1103,9 @@ module Commands
     env_vars = args.first.is_a?(Hash) ? args.shift : {}
     options = args.last.is_a?(Hash) ? args.pop : {}
 
-    @ruby_name = "ce"
+    @ruby_name = 'ce'
     vm_args, ruby_args, options = ruby_options(options, args)
-    ruby_launcher = "/home/sopi/Documents/Side_projects/truffleruby/mxbuild/truffleruby-jvm-ce/bin/truffleruby"
+    ruby_launcher = File.read('ruby_launcher_local')
 
     sh env_vars, ruby_launcher, *(vm_args if truffleruby?), *ruby_args, options
   end
@@ -1114,7 +1114,7 @@ module Commands
     env_vars = args.first.is_a?(Hash) ? args.shift : {}
     options = args.last.is_a?(Hash) ? args.pop : {}
 
-    @ruby_name = "rebench"
+    @ruby_name = 'rebench'
     vm_args, ruby_args, options = ruby_options(options, args)
     ruby_launcher = '/tmp/truffleruby/truffleruby-jvm-ce/bin/truffleruby'
 
@@ -1125,9 +1125,9 @@ module Commands
     env_vars = args.first.is_a?(Hash) ? args.shift : {}
     options = args.last.is_a?(Hash) ? args.pop : {}
 
-    @ruby_name = "rebench-native"
+    @ruby_name = 'rebench-native'
     vm_args, ruby_args, options = ruby_options(options, args)
-    ruby_launcher = "/tmp/truffleruby/truffleruby-native-libgraal/bin/truffleruby"
+    ruby_launcher = '/tmp/truffleruby/truffleruby-native-libgraal/bin/truffleruby'
 
     sh env_vars, ruby_launcher, *(vm_args if truffleruby?), *ruby_args, options
   end


### PR DESCRIPTION
/!\ Part of the implementation resides in my fork of graal: [Related PR](https://github.com/sophie-kaleba/truffle/pull/1)

-----

Context-Guided Splitting is a variation of the current splitting heuristic used in GraalVM. It aims at reducing the amount of splits by favouring the reuse of previously split methods. Such a decision is guided by the notion of "context": each call is represented by a context. If a method was previously split under a context C, and is flagged for being split again, we check whether the current context and context C match. If they do, we dispatch to the previously split method, rather than triggering splitting again.

There are 4 main elements in this approach. The current PR deals with the first element:
- [x] each call is represented by a context, i.e. a hash of the arguments' types 
- [ ] a split method is associated with the contexts during which it was split
- [ ] if this method is flagged for splitting in the future, we check whether the context is the same, and dispatch to the previously generated split, rather than triggering splitting again
- [ ] sometimes, the contexts match but the call-sites lead to different specialisations: this is a context misprediction, which should revert to standard splitting

## What does this PR do?
- For each call, pick the user-provided arguments and compute a **context signature**, ie. a hash of the arguments' types (see [RubyDynamicObject](https://github.com/sophie-kaleba/truffleruby/blob/6152f947ee6c3205948932d42d24d611678699ea/src/main/java/org/truffleruby/language/RubyDynamicObject.java#L85) and [ContextSignatureUtils](https://github.com/sophie-kaleba/truffleruby/blob/6152f947ee6c3205948932d42d24d611678699ea/src/main/java/org/truffleruby/language/contextualdispatch/ContextSignatureUtils.java#L99))
- If a RubyProc (block) is passed as an argument, we use the hashcode of its call-target rather than the plain hash of RubyProc's metaclass, to avoid false positives (see [RubyProc](https://github.com/sophie-kaleba/truffleruby/blob/6152f947ee6c3205948932d42d24d611678699ea/src/main/java/org/truffleruby/core/proc/RubyProc.java#L105))
- Each arguments' hashcode is multiplied by a prime number (see [ContextSignatureUtils](https://github.com/sophie-kaleba/truffleruby/blob/6152f947ee6c3205948932d42d24d611678699ea/src/main/java/org/truffleruby/language/contextualdispatch/ContextSignatureUtils.java#L7)). On our biggest benchmarks, this leads to less than 0.2% of collisions

The remainder of the approach, notably how the contexts are used to avoid splitting, is implemented as part of the graal repository. The related PR is available [here](https://github.com/sophie-kaleba/truffle/pull/1)